### PR TITLE
CE-87 Only surface errors for 4xx and 5xx status codes

### DIFF
--- a/lib/tradedesk.js
+++ b/lib/tradedesk.js
@@ -112,7 +112,7 @@ Tradedesk.prototype.__request = function(method, path, params, callback) {
       if (typeof data.errors !== 'undefined') {
         callback(data.errors, data, response);
       }
-      else if(response.statusCode !== 200) {
+      else if(response.statusCode >= 400) {
         let errorMessage;
         try {
             errorMessage = JSON.stringify(response.body);


### PR DESCRIPTION
The campaign clone endpoint currently returns a referenceId with a 202 status code.  This library was returning an error message since the code was not 200.  This bugfix changes the error fallback check to only 4xx and 5xx responses.