### PR TITLE
feat: adding 24h max auth token length

### DIFF
--- a/lib/tradedesk.js
+++ b/lib/tradedesk.js
@@ -29,7 +29,8 @@ function Tradedesk (options) {
 Tradedesk.prototype.getAuthToken = function(login, password, callback) {
   var auth_params = {
     "Login": login,
-    "Password": password
+    "Password": password,
+    "TokenExpirationInMinutes": 1440 // Max 24h token
   };
 
   this.__request('post', 'authentication', auth_params, function(error, data, response) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -78,9 +78,9 @@
       }
     },
     "deep-extend": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.2.tgz",
-      "integrity": "sha1-SLaZwn4zS/ifEIkr5DL25MfTSn8="
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.5.1.tgz",
+      "integrity": "sha512-N8vBdOa+DF7zkRrDCsaOXoCs/E2fJfx9B9MrKnnSiHNh4ws7eSys6YQE4KvT1cecKmOASYQBhbKjeuDD9lT81w=="
     },
     "delayed-stream": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "homepage": "https://github.com/HumanDesign/node-tradedesk",
   "dependencies": {
-    "deep-extend": "^0.4.0",
+    "deep-extend": "^0.5.1",
     "request": "^2.55.0",
     "url": "^0.10.3"
   }


### PR DESCRIPTION
On February 15, 2022 TTD's [POST/authentication](https://api.thetradedesk.com/v3/portal/api/ref/post-authentication) will only support short lived tokens with expiration of up to 24 hours (1440 minutes).